### PR TITLE
fix free variable in building percept

### DIFF
--- a/src/nl/codefox/contextvh/tygronEvents.mod2g
+++ b/src/nl/codefox/contextvh/tygronEvents.mod2g
@@ -13,7 +13,7 @@ module tygronEvents {
 	%%% BUILDING PERCEPTS
 	% update building/8 when another percept is received with similar ID but with other values.
 	forall percept(buildings(List)),
-		bel(building(BuildingID,Name,OwnerID,BuildYear,Categories,FunctionID,Floors,MultiPolygon,Area),
+		bel(building(BuildingID,Name,OwnerID,BuildYear,Categories,FunctionID,Floors,MultiPoly,Area),
 		member(building(BuildingID,OtherName,OtherOwnerID,OtherConstructionYear,OtherCategories,OtherFunctionID,OtherFloors,OtherMultiPoly,OtherArea),List),
 		(OwnerID\=OtherOwnerID; Name\=OtherName; BuildYear\=OtherBuildYear; Categories\=OtherCategories; Floors\=OtherFloors; FunctionID\=OtherFunctionID; MultiPoly\=OtherMultiPoly;Area\=OtherArea)) 
 		do delete(building(BuildingID,Name,OwnerID,BuildYear,Categories,FunctionID,Floors,MultiPoly,Area)) + 


### PR DESCRIPTION
The names of the variables weren't identical which made it impossible to add buildings to your belief base.
