### PR TITLE
Actionlog percept is correctly put into the belief base

### DIFF
--- a/src/nl/codefox/contextvh/tygronEvents.mod2g
+++ b/src/nl/codefox/contextvh/tygronEvents.mod2g
@@ -62,11 +62,11 @@ module tygronEvents {
 		insert(indicator(IndicatorID,OtherValue,OtherTarget,OtherZoneLinks)).
 	
 	%%% ACTIONLOG PERCEPTS	
-	forall percept(actionlog(StakeholderID,ActionLog,LogID,Parameters)),
-		bel(not(actionlog(StakeholderID,ActionLog,LogID,Parameters)))
-		do insert(actionlog(StakeholderID,ActionLog,LogID,Parameters)).    
-			
+	forall percept(action_logs(ActList)), 
+		bel(member(actionlog(StakeholderID,Description,ActionID,IncList),ActList))
+		do insert(actionlog(StakeholderID,Description,ActionID,IncList)).
+
 	% enter tygronGoals to adopt goals when preconditions are met
-	if true then tygronGoals. 	
-	if true then tygronRequests.	
+	if true then tygronGoals.
+	if true then tygronRequests.
 }


### PR DESCRIPTION
The actionlog was not correctly put into the belief base which made it impossible to read the actionlog, it has now been added correctly.

Sprint 8 user story 1 1st task:
Complete event module so that all useful available percepts are being inserted.
