### PR TITLE
Add relevant_areas percept handling

### DIFF
--- a/src/nl/codefox/contextvh/knowledgebase.pl
+++ b/src/nl/codefox/contextvh/knowledgebase.pl
@@ -15,6 +15,7 @@
 :- dynamic land/5.
 :- dynamic zone/5. 
 :- dynamic building/9.
+:- dynamic relevant_areas/2.
 
 % others
 :- dynamic indicatorLink/2.

--- a/src/nl/codefox/contextvh/tygronEvents.mod2g
+++ b/src/nl/codefox/contextvh/tygronEvents.mod2g
@@ -73,11 +73,6 @@ module tygronEvents {
 	% update relevant_areas/2
 	if percept(relevant_areas(CallID,NewMultiPolygons)), bel(relevant_areas(CallID,OldMultiPolygons))
 		then delete(relevant_areas(CallID,OldMultiPolygons))+ insert(relevant_areas(CallID,NewMultiPolygons)).
-		
-	%%% REQUEST PERCEPTS
-	% insert request/9 to beliefs
-	forall percept(request(Type,RequestType,RequestID,ContentLinkID,VisibieStakeholdersIDList,ActionLogIDList,Price,MultiPolygon,Area,Answers)) 
-		do insert(request(Type,RequestType,RequestID,ContentLinkID,VisibieStakeholdersIDList,ActionLogIDList,Price,MultiPolygon,Area,Answers)). 
 
 	% enter tygronGoals to adopt goals when preconditions are met
 	if true then tygronGoals.

--- a/src/nl/codefox/contextvh/tygronEvents.mod2g
+++ b/src/nl/codefox/contextvh/tygronEvents.mod2g
@@ -63,6 +63,14 @@ module tygronEvents {
 		bel(not(actionlog(StakeholderID,ActionLog,LogID,Parameters)))
 		do insert(actionlog(StakeholderID,ActionLog,LogID,Parameters)).
 		
+	%%% RELEVANT AREAS PERCEPTS
+	% insert relevant_areas/2
+	if percept(relevant_areas(ID,MultiPolygons)), not(bel(relevant_areas(ID,_)))
+		then insert(relevant_areas(ID,MultiPolygons)).
+	% update relevant_areas/2
+	if percept(relevant_areas(ID,NewMultiPolygons)), bel(relevant_areas(ID,OldMultiPolygons))
+		then delete(relevant_areas(ID,OldMultiPolygons))+ insert(relevant_areas(ID,NewMultiPolygons)).
+		
 	%%% REQUEST PERCEPTS
 	% insert request/9 to beliefs
 	forall percept(request(Type,RequestType,RequestID,ContentLinkID,VisibieStakeholdersIDList,ActionLogIDList,Price,MultiPolygon,Area,Answers)) 

--- a/src/nl/codefox/contextvh/tygronEvents.mod2g
+++ b/src/nl/codefox/contextvh/tygronEvents.mod2g
@@ -65,11 +65,11 @@ module tygronEvents {
 		
 	%%% RELEVANT AREAS PERCEPTS
 	% insert relevant_areas/2
-	if percept(relevant_areas(ID,MultiPolygons)), not(bel(relevant_areas(ID,_)))
-		then insert(relevant_areas(ID,MultiPolygons)).
+	if percept(relevant_areas(CallID,MultiPolygons)), not(bel(relevant_areas(CallID,_)))
+		then insert(relevant_areas(CallID,MultiPolygons)).
 	% update relevant_areas/2
-	if percept(relevant_areas(ID,NewMultiPolygons)), bel(relevant_areas(ID,OldMultiPolygons))
-		then delete(relevant_areas(ID,OldMultiPolygons))+ insert(relevant_areas(ID,NewMultiPolygons)).
+	if percept(relevant_areas(CallID,NewMultiPolygons)), bel(relevant_areas(CallID,OldMultiPolygons))
+		then delete(relevant_areas(CallID,OldMultiPolygons))+ insert(relevant_areas(CallID,NewMultiPolygons)).
 		
 	%%% REQUEST PERCEPTS
 	% insert request/9 to beliefs


### PR DESCRIPTION
This percept allows us to check for available land ready to be build on.

User Story: 
As a housing corporation agent I want to have access to all percepts from the environment and all indicators that will be useful to me so that I can function in the best way possible
